### PR TITLE
Fix Main Thread issue

### DIFF
--- a/Example/Pods/Pods.xcodeproj/project.pbxproj
+++ b/Example/Pods/Pods.xcodeproj/project.pbxproj
@@ -358,6 +358,7 @@
 			developmentRegion = English;
 			hasScannedForEncodings = 0;
 			knownRegions = (
+				English,
 				en,
 			);
 			mainGroup = 7DB346D0F39D3F0E887471402A8071AB;
@@ -450,8 +451,9 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 8.3;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.4;
 				STRIP_INSTALLED_PRODUCT = NO;
+				SWIFT_VERSION = 5.0;
 				SYMROOT = "${SRCROOT}/../build";
 				VALIDATE_PRODUCT = YES;
 			};
@@ -471,7 +473,7 @@
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				INFOPLIST_FILE = "Target Support Files/Pods-SnapSliderFilters_Example/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.3;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.4;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MACH_O_TYPE = staticlib;
 				MODULEMAP_FILE = "Target Support Files/Pods-SnapSliderFilters_Example/Pods-SnapSliderFilters_Example.modulemap";
@@ -482,7 +484,7 @@
 				PRODUCT_NAME = Pods_SnapSliderFilters_Example;
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 3.0;
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
@@ -503,7 +505,7 @@
 				GCC_PREFIX_HEADER = "Target Support Files/SnapSliderFilters/SnapSliderFilters-prefix.pch";
 				INFOPLIST_FILE = "Target Support Files/SnapSliderFilters/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.3;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.4;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MODULEMAP_FILE = "Target Support Files/SnapSliderFilters/SnapSliderFilters.modulemap";
 				MTL_ENABLE_DEBUG_INFO = YES;
@@ -511,7 +513,7 @@
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 3.0;
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
@@ -550,9 +552,10 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 8.3;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.4;
 				ONLY_ACTIVE_ARCH = YES;
 				STRIP_INSTALLED_PRODUCT = NO;
+				SWIFT_VERSION = 5.0;
 				SYMROOT = "${SRCROOT}/../build";
 			};
 			name = Debug;
@@ -571,7 +574,7 @@
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				INFOPLIST_FILE = "Target Support Files/Pods-SnapSliderFilters_Example/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.3;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.4;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MACH_O_TYPE = staticlib;
 				MODULEMAP_FILE = "Target Support Files/Pods-SnapSliderFilters_Example/Pods-SnapSliderFilters_Example.modulemap";
@@ -583,7 +586,7 @@
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 3.0;
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
@@ -603,7 +606,7 @@
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				INFOPLIST_FILE = "Target Support Files/Pods-SnapSliderFilters_Tests/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.3;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.4;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MACH_O_TYPE = staticlib;
 				MODULEMAP_FILE = "Target Support Files/Pods-SnapSliderFilters_Tests/Pods-SnapSliderFilters_Tests.modulemap";
@@ -615,7 +618,7 @@
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 3.0;
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
@@ -636,14 +639,14 @@
 				GCC_PREFIX_HEADER = "Target Support Files/SnapSliderFilters/SnapSliderFilters-prefix.pch";
 				INFOPLIST_FILE = "Target Support Files/SnapSliderFilters/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.3;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.4;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MODULEMAP_FILE = "Target Support Files/SnapSliderFilters/SnapSliderFilters.modulemap";
 				MTL_ENABLE_DEBUG_INFO = NO;
 				PRODUCT_NAME = SnapSliderFilters;
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 3.0;
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
@@ -663,7 +666,7 @@
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				INFOPLIST_FILE = "Target Support Files/Pods-SnapSliderFilters_Tests/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.3;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.4;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MACH_O_TYPE = staticlib;
 				MODULEMAP_FILE = "Target Support Files/Pods-SnapSliderFilters_Tests/Pods-SnapSliderFilters_Tests.modulemap";
@@ -674,7 +677,7 @@
 				PRODUCT_NAME = Pods_SnapSliderFilters_Tests;
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 3.0;
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";

--- a/Example/Pods/Pods.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/Example/Pods/Pods.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/Example/SnapSliderFilters.xcodeproj/project.pbxproj
+++ b/Example/SnapSliderFilters.xcodeproj/project.pbxproj
@@ -180,6 +180,7 @@
 			developmentRegion = English;
 			hasScannedForEncodings = 0;
 			knownRegions = (
+				English,
 				en,
 				Base,
 			);
@@ -329,11 +330,12 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 8.3;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.4;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
 			};
 			name = Debug;
 		};
@@ -367,9 +369,10 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 8.3;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.4;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
+				SWIFT_VERSION = 5.0;
 				VALIDATE_PRODUCT = YES;
 			};
 			name = Release;
@@ -388,7 +391,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "org.cocoapods.demo.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE = "";
-				SWIFT_VERSION = 3.0;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Debug;
 		};
@@ -406,7 +409,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "org.cocoapods.demo.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE = "";
-				SWIFT_VERSION = 3.0;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Release;
 		};

--- a/Example/SnapSliderFilters.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/Example/SnapSliderFilters.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/Example/SnapSliderFilters.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/Example/SnapSliderFilters.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/SnapSliderFilters/Classes/SNButton.swift
+++ b/SnapSliderFilters/Classes/SNButton.swift
@@ -94,8 +94,8 @@ open class SNButton: UIButton {
         
         self.layer.zPosition = 1000
         self.adjustsImageWhenHighlighted = false
-        self.setImage(UIImage(named: name), for: UIControlState())
-        self.imageEdgeInsets = UIEdgeInsetsMake(10, 10, 10, 10)
+        self.setImage(UIImage(named: name), for: UIControl.State())
+        self.imageEdgeInsets = UIEdgeInsets(top: 10, left: 10, bottom: 10, right: 10)
         
         self.addTarget(self, action: #selector(buttonTouchUpInside), for: .touchUpInside)
         self.addTarget(self, action: #selector(buttonPressed), for: .touchDown)
@@ -114,16 +114,16 @@ open class SNButton: UIButton {
         self.action = actionClosure
     }
     
-    func buttonTouchUpInside() {
+    @objc func buttonTouchUpInside() {
         shouldRunAction=true
         buttonReleased()
     }
     
-    func buttonPressed() {
+    @objc func buttonPressed() {
         buttonState = .bigButton
     }
     
-    func buttonReleased() {
+    @objc func buttonReleased() {
         buttonState = .smallButton
     }
 }

--- a/SnapSliderFilters/Classes/SNFilter.swift
+++ b/SnapSliderFilters/Classes/SNFilter.swift
@@ -11,7 +11,7 @@ import UIKit
 open class SNFilter: UIImageView {
     
     // Full list of filters available here : https://developer.apple.com/library/tvos/documentation/GraphicsImaging/Reference/CoreImageFilterReference/index.html
-    open static let filterNameList = ["No Filter" , "CIPhotoEffectFade", "CIPhotoEffectChrome", "CIPhotoEffectTransfer", "CIPhotoEffectInstant", "CIPhotoEffectMono", "CIPhotoEffectNoir", "CIPhotoEffectProcess", "CIPhotoEffectTonal"]
+    public static let filterNameList = ["No Filter" , "CIPhotoEffectFade", "CIPhotoEffectChrome", "CIPhotoEffectTransfer", "CIPhotoEffectInstant", "CIPhotoEffectMono", "CIPhotoEffectNoir", "CIPhotoEffectProcess", "CIPhotoEffectTonal"]
     open var name:String?
     var stickers = [SNSticker]()
     
@@ -19,7 +19,7 @@ open class SNFilter: UIImageView {
         super.init(frame: frame)
     }
     
-    public init(frame: CGRect, withImage image:UIImage, withContentMode mode:UIViewContentMode = .scaleAspectFill) {
+    public init(frame: CGRect, withImage image:UIImage, withContentMode mode:UIView.ContentMode = .scaleAspectFill) {
         super.init(frame: frame)
         self.contentMode = mode
         self.clipsToBounds = true
@@ -105,7 +105,7 @@ open class SNFilter: UIImageView {
         self.stickers.append(sticker)
     }
     
-    open static func generateFilters(_ originalImage: SNFilter, filters:[String]) -> [SNFilter] {
+    public static func generateFilters(_ originalImage: SNFilter, filters:[String]) -> [SNFilter] {
         
         var finalFilters = [SNFilter]()
         

--- a/SnapSliderFilters/Classes/SNFilter.swift
+++ b/SnapSliderFilters/Classes/SNFilter.swift
@@ -109,16 +109,9 @@ open class SNFilter: UIImageView {
         
         var finalFilters = [SNFilter]()
         
-        let queue = DispatchQueue.global(priority: DispatchQueue.GlobalQueuePriority.high)
-        let syncQueue = DispatchQueue(label: "com.snapsliderfilters.app", attributes: .concurrent)
-        
-        // Each filter can be generated on a different thread
-        DispatchQueue.concurrentPerform(iterations: filters.count) { iteration in
-            let filterComputed = originalImage.applyFilter(filterNamed: filters[iteration])
-            syncQueue.sync {
-                finalFilters.append(filterComputed)
-                return
-            }
+        for filter in filters {
+            let filterComputed = originalImage.applyFilter(filterNamed: filter)
+            finalFilters.append(filterComputed)
         }
         
         return finalFilters

--- a/SnapSliderFilters/Classes/SNSticker.swift
+++ b/SnapSliderFilters/Classes/SNSticker.swift
@@ -10,7 +10,7 @@ import UIKit
 
 open class SNSticker: UIImageView {
     
-    public init(frame: CGRect, image:UIImage, withContentMode mode: UIViewContentMode = .scaleAspectFit, atZPosition zIndex:CGFloat? = nil) {
+    public init(frame: CGRect, image:UIImage, withContentMode mode: UIView.ContentMode = .scaleAspectFit, atZPosition zIndex:CGFloat? = nil) {
         super.init(frame: frame)
         
         self.contentMode = mode

--- a/SnapSliderFilters/Classes/SNTextField.swift
+++ b/SnapSliderFilters/Classes/SNTextField.swift
@@ -26,12 +26,12 @@ open class SNTextField: UITextField {
         self.textColor = UIColor.white
         self.placeholder = ""
         self.font = UIFont.systemFont(ofSize: 16)
-        self.borderStyle = UITextBorderStyle.none
+        self.borderStyle = UITextField.BorderStyle.none
         self.autocorrectionType = UITextAutocorrectionType.no
         self.keyboardType = UIKeyboardType.default
         self.returnKeyType = UIReturnKeyType.done
-        self.clearButtonMode = UITextFieldViewMode.never;
-        self.contentVerticalAlignment = UIControlContentVerticalAlignment.center
+        self.clearButtonMode = UITextField.ViewMode.never;
+        self.contentVerticalAlignment = UIControl.ContentVerticalAlignment.center
         self.textAlignment = .center
         self.contentHorizontalAlignment = .center
         self.delegate = self
@@ -88,7 +88,7 @@ extension SNTextField: UITextFieldDelegate {
     // Limit the text size to the screen width
     public func textField(_ textField: UITextField, shouldChangeCharactersIn range: NSRange, replacementString string: String) -> Bool {
         let text:NSString = (self.text! as NSString).replacingCharacters(in: range, with: string) as NSString
-        let contentWidth = text.size(attributes: [NSFontAttributeName: UIFont.systemFont(ofSize: 16.0)]).width
+        let contentWidth = text.size(withAttributes: [NSAttributedString.Key.font: UIFont.systemFont(ofSize: 16.0)]).width
         return contentWidth <= (self.frame.width - 20)
     }
     
@@ -113,7 +113,7 @@ extension SNTextField: UIGestureRecognizerDelegate {
         }
     }
     
-    func handlePan(_ recognizer:UIPanGestureRecognizer) {
+    @objc func handlePan(_ recognizer:UIPanGestureRecognizer) {
         
         if self.isFirstResponder == true { return }
         
@@ -152,7 +152,7 @@ public extension SNTextField {
     }
     
     func updatePosition(_ notification: Notification) {
-        if let keyboardSize = ((notification as NSNotification).userInfo?[UIKeyboardFrameEndUserInfoKey] as? NSValue)?.cgRectValue {
+        if let keyboardSize = ((notification as NSNotification).userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? NSValue)?.cgRectValue {
             self.frame.origin.y = self.heightOfScreen - keyboardSize.height - self.frame.size.height
         }
     }

--- a/SnapSliderFilters/Classes/SNUtils.swift
+++ b/SnapSliderFilters/Classes/SNUtils.swift
@@ -10,10 +10,10 @@ import UIKit
 
 open class SNUtils {
     
-    open static let screenSize = CGSize(width: UIScreen.main.bounds.width, height: UIScreen.main.bounds.height)
+    public static let screenSize = CGSize(width: UIScreen.main.bounds.width, height: UIScreen.main.bounds.height)
     
     // Allow you to take a screenshot of the screen
-    open static func screenShot(_ view: UIView?) -> UIImage? {
+    public static func screenShot(_ view: UIView?) -> UIImage? {
         guard let imageView = view else {
             return nil
         }


### PR DESCRIPTION
# Swift 5 support
- Changes compile language to Swift 5
- Changes iOS build target to 12.4
- Compiles and runs in Swift5

# Thread Issues
8577da7 Resolves #19 

SNFilter is subclass of UIImageView, which can only be init'd from the main thread.

You'd have to not be a UIView if you want to do background threading.

Now, changing to generate filters on the main thread, has no perceivable impact on filter generation on my iPhoneX, nor iPhone6.